### PR TITLE
Delete named ranges referring to __temp_buffer

### DIFF
--- a/ClosedXML.Report/Excel/TempSheetBuffer.cs
+++ b/ClosedXML.Report/Excel/TempSheetBuffer.cs
@@ -134,6 +134,11 @@ namespace ClosedXML.Report.Excel
 
         public void Dispose()
         {
+            var namedRanges = _wb.NamedRanges
+                .Where(nr => nr.Ranges.Any(r => r.Worksheet?.Name == SheetName))
+                .ToList();
+            namedRanges.ForEach(nr => nr.Delete());
+
             _wb.Worksheets.Delete(SheetName);
         }
     }

--- a/tests/ClosedXML.Report.Tests/TempSheetBufferTests.cs
+++ b/tests/ClosedXML.Report.Tests/TempSheetBufferTests.cs
@@ -1,0 +1,29 @@
+﻿using ClosedXML.Excel;
+using ClosedXML.Report.Excel;
+using FluentAssertions;
+using System.Linq;
+using Xunit;
+
+namespace ClosedXML.Report.Tests
+{
+    public class TempSheetBufferTests
+    {
+        [Fact]
+        public void NamedRangesAreRemovedWithTempSheet()
+        {
+            using (var wb = new XLWorkbook())
+            {
+                var ws = wb.AddWorksheet("Sheet1");
+
+                var tempSheetBuffer = new TempSheetBuffer(wb);
+                wb.NamedRanges.Add("Temp range", tempSheetBuffer.GetRange(
+                    tempSheetBuffer.GetCell(1, 1).Address,
+                    tempSheetBuffer.GetCell(4, 4).Address));
+
+                wb.NamedRanges.Count().Should().Be(1, "global named range is supposed to be added");
+                tempSheetBuffer.Dispose();
+                wb.NamedRanges.Count().Should().Be(0, "named range should be deleted with the temp buffer");
+            }
+        }
+    }
+}


### PR DESCRIPTION
At some stages, the named ranges are copied to __temp_buffer and they are not deleted with the temp sheet. This is related to https://github.com/ClosedXML/ClosedXML/issues/848 but even after that issue is fixed this one will remain (the ranges referring to __temp_buffer will become invalid - like `#REF!A1:X100`).

With this PR I explicitly delete named ranges referring to __temp_buffer on disposing.