### PR TITLE
Row wide ranges fail to process.

### DIFF
--- a/ClosedXML.Report/Excel/TempSheetBuffer.cs
+++ b/ClosedXML.Report/Excel/TempSheetBuffer.cs
@@ -94,8 +94,28 @@ namespace ClosedXML.Report.Excel
         {
             var tempRng = _sheet.Range(_sheet.Cell(1, 1), _sheet.LastCellUsed()); //_sheet.Cell(_prevrow, _prevclmn));
 
-            range.InsertRowsBelow(tempRng.RowCount() - range.RowCount(), true);
-            range.InsertColumnsAfter(tempRng.ColumnCount() - range.ColumnCount(), true);
+            var rowDiff = tempRng.RowCount() - range.RowCount();
+            if (rowDiff > 0)
+                range.InsertRowsBelow(rowDiff, true);
+            else if (rowDiff < 0)
+                range.Worksheet.Range(
+                    range.LastRow().RowNumber() + 1,
+                    range.FirstColumn().ColumnNumber(),
+                    range.LastRow().RowNumber() + rowDiff,
+                    range.LastColumn().ColumnNumber())
+                .Delete(XLShiftDeletedCells.ShiftCellsUp);
+
+            var columnDiff = tempRng.ColumnCount() - range.ColumnCount();
+            if (columnDiff > 0)
+                range.InsertColumnsAfter(columnDiff, true);
+            else if (columnDiff < 0)
+                range.Worksheet.Range(
+                    range.FirstRow().RowNumber(),
+                    range.FirstColumn().ColumnNumber() + 1,
+                    range.LastRow().RowNumber(),
+                    range.LastColumn().ColumnNumber() + columnDiff)
+                .Delete(XLShiftDeletedCells.ShiftCellsLeft);
+
             tempRng.CopyTo(range.FirstCell());
 
             var tgtSheet = range.Worksheet;


### PR DESCRIPTION
I had issues with one of my reports and the reason was that there were ranges defined as "2:3" (including entire rows). In that situation this code

```
range.InsertColumnsAfter(tempRng.ColumnCount() - range.ColumnCount(), true);
```

failed with the exception "An item with the same key has already been added. Key: 25".
Moreover, as it turned out, `InsertColumnsAfter` worked with negative numbers only accidentally (see https://github.com/ClosedXML/ClosedXML/issues/855) and it won't be allowed starting from 0.93.

So in this PR I explicitly check the difference in the number of rows and columns between two ranges and then perform an insert or delete depending on it.

PS. Before I replaced `_sheet.Cell(_maxRow, _maxClmn)` to `_sheet.LastCellUsed()` in the first PR these ranges worked fine too but subtotals failed as inserting the rows for subtotals didn't update `_maxRow`