### PR TITLE
 Do not evaluate formulae when parsing tags

### DIFF
--- a/ClosedXML.Report/RangeInterpreter.cs
+++ b/ClosedXML.Report/RangeInterpreter.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -39,9 +38,13 @@ namespace ClosedXML.Report
         public void ParseTags(IXLRange range, string rangeName)
         {
             var innerRanges = range.GetContainingNames().Where(nr => _variables.ContainsKey(nr.Name)).ToArray();
-            var cells = from c in range.CellsUsed()
-                        where !c.HasFormula
-                           && !innerRanges.Any(nr => { using (var r = nr.Ranges) using (var cr = c.AsRange()) return r.Contains(cr); })
+            var cells = from c in range.CellsUsed(c => !c.HasFormula
+                                                    && !innerRanges.Any(nr =>
+                                                    {
+                                                           using (var r = nr.Ranges)
+                                                           using (var cr = c.AsRange())
+                                                               return r.Contains(cr);
+                                                    }))
                         let value = c.GetString()
                         where (value.StartsWith("<<") || value.EndsWith(">>"))
                         select c;

--- a/ClosedXML.Report/RangeInterpreter.cs
+++ b/ClosedXML.Report/RangeInterpreter.cs
@@ -40,10 +40,10 @@ namespace ClosedXML.Report
         {
             var innerRanges = range.GetContainingNames().Where(nr => _variables.ContainsKey(nr.Name)).ToArray();
             var cells = from c in range.CellsUsed()
-                        let value = c.GetString()
                         where !c.HasFormula
-                            && (value.StartsWith("<<") || value.EndsWith(">>"))
-                            && !innerRanges.Any(nr => { using (var r = nr.Ranges) using (var cr = c.AsRange()) return r.Contains(cr);})
+                           && !innerRanges.Any(nr => { using (var r = nr.Ranges) using (var cr = c.AsRange()) return r.Contains(cr); })
+                        let value = c.GetString()
+                        where (value.StartsWith("<<") || value.EndsWith(">>"))
                         select c;
 
             if (!_tags.ContainsKey(rangeName))

--- a/tests/ClosedXML.Report.Tests/RangeInterpreterTests.cs
+++ b/tests/ClosedXML.Report.Tests/RangeInterpreterTests.cs
@@ -1,4 +1,6 @@
-﻿using FluentAssertions;
+﻿using ClosedXML.Excel;
+using FluentAssertions;
+using System.Collections.Generic;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -20,6 +22,38 @@ namespace ClosedXML.Report.Tests
                     wb.Worksheet(2).Cell("A2").IsEmpty().Should().BeTrue();
                     wb.Worksheet(3).Cell("B4").GetString().Should().NotContain("<<OnlyValues>>");
                 });
+        }
+
+        [Fact]
+        public void DoNotEvaluateFormulaOnTagsParsing()
+        {
+            using (var wb = new XLWorkbook())
+            {
+                var ws1 = wb.AddWorksheet("Sheet1");
+                var ws2 = wb.AddWorksheet("Sheet2");
+
+                ws1.FirstCell().FormulaA1 = "=VLOOKUP(\"Bob\", Sheet2!B:D, 3, FALSE)";
+                ws2.Cell("B2").Value = "{{item.Name}}";
+                ws2.Cell("C2").Value = "{{item.Count}}";
+                ws2.Cell("D2").Value = "&=C2*10";
+                ws2.Range("A2:D3").AddToNamed("Items");
+
+                var template = new XLTemplate(wb);
+                template.AddVariable("Items", GenerateItems());
+                template.Generate();
+
+                ws1.FirstCell().Value.Should().Be(20.0);
+            }
+
+            IEnumerable<object> GenerateItems()
+            {
+                return new List<object>
+                {
+                    new { Name = "Alice", Count = 1 },
+                    new { Name = "Bob", Count = 2 },
+                    new { Name = "Carl", Count = 3 },
+                };
+            }
         }
     }
 }


### PR DESCRIPTION
I found another issue.

`VLOOKUP` evaluation in ClosedXML has some peculiarity (see https://github.com/ClosedXML/ClosedXML/issues/585). This causes the exceptions if the `RangeInterpreter` evaluates the cell value _before_ the corresponding range is filled. The evaluation of cell values _after_ the ranges are filled goes well.

The proposed changes eliminate this issue by filtering out cells with formulae prior to reading cell values.