### PR TITLE
Improve XLTemplate API

### DIFF
--- a/tests/ClosedXML.Report.Tests/XlsxTemplateTestsBase.cs
+++ b/tests/ClosedXML.Report.Tests/XlsxTemplateTestsBase.cs
@@ -41,10 +41,8 @@ namespace ClosedXML.Report.Tests
 
             var fileName = Path.Combine(TestConstants.TemplatesFolder, tmplFileName);
             using (var stream = File.Open(fileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+            using (var template = new XLTemplate(stream))
             {
-                var workbook = new XLWorkbook(stream);
-                var template = new XLTemplate(workbook);
-
                 // ARRANGE
                 arrangeCallback(template);
 
@@ -56,7 +54,7 @@ namespace ClosedXML.Report.Tests
                     template.Generate();
                     Output.WriteLine(DateTime.Now.Subtract(start).ToString());
                     //MemoryProfiler.Dump();
-                    workbook.SaveAs(file);
+                    template.SaveAs(file);
                     //MemoryProfiler.Dump();
                     file.Position = 0;
 
@@ -66,13 +64,10 @@ namespace ClosedXML.Report.Tests
                         assertCallback(wb);
                     }
                 }
-
-                workbook.Dispose();
-                workbook = null;
-                template = null;
-                GC.Collect();
-                //MemoryProfiler.Dump();
             }
+
+            GC.Collect();
+            //MemoryProfiler.Dump();
         }
 
         protected void CompareWithGauge(XLWorkbook actual, string fileExpected)


### PR DESCRIPTION
This PR aims to improve the `XLTemplate` API by adding two more constructors accepting fileName or stream, methods `SaveAs()` and `Dispose()`. This simplifies the code:

**Before**
```
using (var wb = new XLWorkbook(fileName))
{
  var template = new XLTemplate(wb);
  // some code;
  wb.SaveAs(newFileName);
}
```


**After**
```
using (var template = new XLTemplate(fileName))
{
  // some code;
  template.SaveAs(newFileName);
}
```

The workbook is still available via `XLTemplate.Workbook` property.