### PR TITLE
Configure CI to build nuget packages

### DIFF
--- a/ClosedXML.Report/ClosedXML.Report.csproj
+++ b/ClosedXML.Report/ClosedXML.Report.csproj
@@ -9,20 +9,27 @@
     <PackageLicenseUrl>https://github.com/ClosedXML/ClosedXML.Report/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/ClosedXML/ClosedXML.Report</PackageProjectUrl>
     <RepositoryUrl>https://github.com/ClosedXML/ClosedXML.Report</RepositoryUrl>
-    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Authors>Alexey Rozhkov</Authors>
     <Copyright>MIT</Copyright>
     <Version>0.1.0.0</Version>
     <Product>ClosedXML.Report</Product>
+    <PackageReleaseNotes>See https://github.com/ClosedXML/ClosedXML.Report/releases/tag/$(productVersion)</PackageReleaseNotes>
+    <Description>ClosedXML.Report is a tool for report generation and data analysis in .NET applications through the use of Microsoft Excel. ClosedXML.Report is a .NET-library for report generation Microsoft Excel without requiring Excel to be installed on the machine that's running the code.</Description>
   </PropertyGroup>
-
+  
   <PropertyGroup Condition="'$(Configuration)'=='Release.Signed'">
+    <PackageId>ClosedXML.Report.Signed</PackageId>
     <OutputPath>bin\Release.Signed\</OutputPath>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>ClosedXML.Report.snk</AssemblyOriginatorKeyFile>
     <DefineConstants>$(DefineConstants);STRONGNAME</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)'=='Release'">
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+  </PropertyGroup>
+  
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
   </PropertyGroup>

--- a/ClosedXML.Report/ClosedXML.Report.nuspec
+++ b/ClosedXML.Report/ClosedXML.Report.nuspec
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+  <metadata>
+    <id>$id$</id>
+    <version>$version$</version>
+    <title>$title$</title>
+    <authors>$author$</authors>
+    <owners>$author$</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <licenseUrl>https://github.com/ClosedXML/ClosedXML.Report/blob/master/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/ClosedXML/ClosedXML.Report</projectUrl>
+    <copyright>MIT</copyright>
+    <language>en-US</language>
+    <tags>ClosedXML Report</tags>
+  </metadata>
+  <files>
+    <file src="bin\Release\net40\ClosedXML.Report.dll" target="lib\net40\ClosedXML.Report.dll" />
+    <file src="bin\Release\net46\ClosedXML.Report.dll" target="lib\net46\ClosedXML.Report.dll" />
+    <file src="bin\Release\netstandard2.0\ClosedXML.Report.dll" target="lib\netstandard2.0\ClosedXML.Report.dll" />
+  </files>
+</package>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,5 @@
+# common configuration for ALL branches
+
 version: 0.1.0.{build}
 
 pull_requests:
@@ -5,21 +7,40 @@ pull_requests:
 
 image: Visual Studio 2017
 
-configuration:
-- Release
-- Release.Signed
-
 environment:
   AppVeyor: APPVEYOR
+
+init:
+
+- ps: >-
+    if ($env:APPVEYOR_REPO_TAG -eq 'true')
+    {
+      $env:fileVersion = $env:APPVEYOR_REPO_TAG_NAME -replace '(\d+)\.(\d+)\.(\d+)(-.+)?', '$1.$2.$3'
+      if ($env:fileVersion -eq $env:APPVEYOR_REPO_TAG_NAME) { $env:fileVersion = $($env:fileVersion + '.0') }
+      else { $env:fileVersion = $($env:fileVersion + '.' + $env:APPVEYOR_BUILD_NUMBER) }
+      $env:productVersion = $env:APPVEYOR_REPO_TAG_NAME
+    }
+    else
+    {
+      $env:fileVersion = $env:APPVEYOR_BUILD_VERSION -replace '(\d+)\.(\d+)\.([^.]+)\.(\d+)', '$1.$2.999.$4'
+      $env:productVersion = $env:fileVersion
+    }
+    
+    Update-AppveyorBuild -Version $env:fileVersion
+    
+    Write-Host $env:fileVersion $env:productVersion
+    
+    Write-Host $env:APPVEYOR_REPO_TAG $env:APPVEYOR_REPO_TAG_NAME
+    
 
 dotnet_csproj:
   patch: true
   file: '**\*.csproj'
-  version: '{version}'
-  package_version: '{version}'
-  assembly_version: '{version}'
-  file_version: '{version}'
-  informational_version: '{version}'
+  version: '$(productVersion)'
+  package_version: '$(productVersion)'
+  assembly_version: '$(fileVersion)'
+  file_version: '$(fileVersion)'
+  informational_version: '$(productVersion)'
 
 before_build:
   - nuget restore
@@ -27,11 +48,10 @@ before_build:
 build:
   verbosity: minimal
 
-artifacts:
-- path: ClosedXML.Report/bin/%CONFIGURATION%/netstandard2.0/ClosedXML.Report.dll
-- path: ClosedXML.Report/bin/%CONFIGURATION%/net40/ClosedXML.Report.dll
-- path: ClosedXML.Report/bin/%CONFIGURATION%/net46/ClosedXML.Report.dll
+configuration:
+- Release
+- Release.Signed
 
-- path: ClosedXML.Report/bin/%CONFIGURATION%/netstandard2.0/ClosedXML.Report.dll
-- path: ClosedXML.Report/bin/%CONFIGURATION%/net40/ClosedXML.Report.dll
-- path: ClosedXML.Report/bin/%CONFIGURATION%/net46/ClosedXML.Report.dll
+artifacts:
+- path: ClosedXML.Report/bin/%CONFIGURATION%/*.nupkg
+- path: ClosedXML.Report/bin/%CONFIGURATION%/*/ClosedXML.Report.dll


### PR DESCRIPTION
I've been playing with an appveyor configuration and here is what I managed to achieve:

![image](https://user-images.githubusercontent.com/19576939/40346541-3ac036ce-5dae-11e8-9016-337242c137cd.png)

1. On every build nuget packages for both `Relase` and `Release.Signed` configurations are created.
2. When the ordinary commit is pushed AppVeyor creates a build with a number `0.1.999.{build number}` to distinguish such builds from released ones. Nuget packages have this version too (see `0.1.999.107` on the screenshot).
3. When the tag with `-betaX` is pushed the version number is built from the tag name and includes the build number as well. See `1.2.3.105`. The nuget package version includes `beta` and its release notes lead to github page for this tag (now these liks do not work, of course, as those tags were created on another fork):
![image](https://user-images.githubusercontent.com/19576939/40346800-01104d64-5daf-11e8-90ad-d3f8c818118e.png)
4. When the non-beta tag is pushed (see `1.2.4.0`) the build number is not included into file version or nuget package version. 
![image](https://user-images.githubusercontent.com/19576939/40346910-64de42a6-5daf-11e8-91e6-bc5500327f0e.png)

I did not configure automatic deployment to nuget.org, but maybe I will later.
Here is the link to AppVeyor builds: https://ci.appveyor.com/project/Pankraty/closedxml-report/history

@igitur would you like to have such CI configuration for ClosedXML as well?