### PR TITLE
Include Optimize flag in Release.Signed config

### DIFF
--- a/ClosedXML.Report/ClosedXML.Report.csproj
+++ b/ClosedXML.Report/ClosedXML.Report.csproj
@@ -21,9 +21,10 @@
     <PackageId>ClosedXML.Report.Signed</PackageId>
     <OutputPath>bin\Release.Signed\</OutputPath>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <Optimize>true</Optimize>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>ClosedXML.Report.snk</AssemblyOriginatorKeyFile>
-    <DefineConstants>$(DefineConstants);STRONGNAME</DefineConstants>
+    <DefineConstants>$(DefineConstants);RELEASE;STRONGNAME</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">

--- a/tests/ClosedXML.Report.Tests/ClosedXML.Report.Tests.csproj
+++ b/tests/ClosedXML.Report.Tests/ClosedXML.Report.Tests.csproj
@@ -14,9 +14,10 @@
 
   <PropertyGroup Condition="'$(Configuration)'=='Release.Signed'">
     <OutputPath>bin\Release.Signed\</OutputPath>
+    <Optimize>true</Optimize>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>ClosedXML.Report.snk</AssemblyOriginatorKeyFile>
-    <DefineConstants>$(DefineConstants);STRONGNAME</DefineConstants>
+    <DefineConstants>$(DefineConstants);RELEASE;STRONGNAME</DefineConstants>
   </PropertyGroup>
   
   <ItemGroup>


### PR DESCRIPTION
As it turned out, `Release.Signed` config didn't include `Optimize` flag. As a result, GC acted like in Debug mode (less aggressive I assume).