### PR TITLE
Fix issue with evaluating multiple formulas when some of them return null

### DIFF
--- a/ClosedXML.Report/FormulaEvaluator.cs
+++ b/ClosedXML.Report/FormulaEvaluator.cs
@@ -40,7 +40,7 @@ namespace ClosedXML.Report
                 return ((DateTime)val).ToOADate().ToString(CultureInfo.InvariantCulture);
 
             var formattable = val as IFormattable;
-            return formattable != null ? formattable.ToString(null, CultureInfo.InvariantCulture) : val.ToString();
+            return formattable != null ? formattable.ToString(null, CultureInfo.InvariantCulture) : val?.ToString();
         }
 
         private IEnumerable<string> GetExpressions(string cellValue)

--- a/tests/ClosedXML.Report.Tests/FormulaEvaluatorTests.cs
+++ b/tests/ClosedXML.Report.Tests/FormulaEvaluatorTests.cs
@@ -38,6 +38,16 @@ namespace ClosedXML.Report.Tests
             ((IEnumerable<Customer>) dlg.DynamicInvoke(customers)).First().Id.Should().Be(1);
         }
 
+        [Fact]
+        public void MultipleExpressionsWithNullResult()
+        {
+            var eval = new FormulaEvaluator();
+            eval.AddVariable("a", null);
+            eval.AddVariable("b", 1);
+            eval.Evaluate("{{a}}{{b}}").Should().Be(1);
+            eval.Evaluate("{{b}}{{a}}").Should().Be("1");
+        }
+
         class Customer
         {
             public int Id { get; set; }


### PR DESCRIPTION
If cell expression contains multiple formulas and some of them return `null` the `NullReferenceException` occurs.

This PR fixes this.