### PR TITLE
Report generation for empty collection fails

### DIFF
--- a/ClosedXML.Report/Excel/TempSheetBuffer.cs
+++ b/ClosedXML.Report/Excel/TempSheetBuffer.cs
@@ -94,8 +94,8 @@ namespace ClosedXML.Report.Excel
         {
             // LastCellUsed may produce the wrong result, see https://github.com/ClosedXML/ClosedXML/issues/339
             var lastCell = _sheet.Cell(
-                _sheet.LastRowUsed(true).RowNumber(),
-                _sheet.LastColumnUsed(true).ColumnNumber());
+                _sheet.LastRowUsed(true)?.RowNumber() ?? 1,
+                _sheet.LastColumnUsed(true)?.ColumnNumber()?? 1);
             var tempRng = _sheet.Range(_sheet.Cell(1, 1), lastCell);
 
             var rowDiff = tempRng.RowCount() - range.RowCount();

--- a/tests/ClosedXML.Report.Tests/TempSheetBufferTests.cs
+++ b/tests/ClosedXML.Report.Tests/TempSheetBufferTests.cs
@@ -1,6 +1,7 @@
 ﻿using ClosedXML.Excel;
 using ClosedXML.Report.Excel;
 using FluentAssertions;
+using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 
@@ -23,6 +24,25 @@ namespace ClosedXML.Report.Tests
                 wb.NamedRanges.Count().Should().Be(1, "global named range is supposed to be added");
                 tempSheetBuffer.Dispose();
                 wb.NamedRanges.Count().Should().Be(0, "named range should be deleted with the temp buffer");
+            }
+        }
+
+        [Fact]
+        public void CanRenderRangeForEmptySet()
+        {
+            using (var wb = new XLWorkbook())
+            {
+                var ws = wb.AddWorksheet("Sheet1");
+                ws.Range("A2:B3").AddToNamed("List");
+                ws.Cell("B2").Value = "{{item}}";
+                ws.Cell("B4").Value = "Cell below";
+
+                var template = new XLTemplate(wb);
+                template.AddVariable("List", new List<string>());
+                template.Generate();
+
+                ws.Cell("B3").Value.Should().Be("Cell below");
+                ws.Cell("B4").Value.Should().Be("");
             }
         }
     }


### PR DESCRIPTION
If the collection is empty and the range definition does not have any items in the service row report generation fails with `NullReferenceException`.

cc @namaro-rocket