### PR TITLE
Prevented NULL dereference when nesting ranges

### DIFF
--- a/ClosedXML.Report/RangeTemplate.cs
+++ b/ClosedXML.Report/RangeTemplate.cs
@@ -281,7 +281,7 @@ namespace ClosedXML.Report
             var start = _buff.NextAddress;
             // дочерний шаблон, к которому принадлежит ячейка
             var xlCell = _rowRange.Cell(cell.Row, cell.Column);
-            var ownRng = _subranges.First(r => r._cells.Any(c => c.CellType != TemplateCellType.None && Equals(c.XLCell.Address, xlCell.Address)));
+            var ownRng = _subranges.First(r => r._cells.Any(c => c.CellType != TemplateCellType.None && c.XLCell != null && Equals(c.XLCell.Address, xlCell.Address)));
             var formula = "{{" + ownRng.Source.ReplaceLast("_", ".") + "}}";
             IEnumerable value = evaluator.Evaluate(formula, new Parameter(Name, item)) as IEnumerable;
 


### PR DESCRIPTION
- Specifically when nesting a horizontal range in a vertical range