### PR TITLE
Get rid of System.ValueTuple dependency

### DIFF
--- a/ClosedXML.Report/ClosedXML.Report.csproj
+++ b/ClosedXML.Report/ClosedXML.Report.csproj
@@ -46,7 +46,6 @@
   <ItemGroup>
     <PackageReference Include="ClosedXML" Version="0.92.1" />
     <PackageReference Include="System.Linq.Dynamic.Core" Version="1.0.9" />
-    <PackageReference Include="System.ValueTuple" Version="4.3.0" />
   </ItemGroup>
 
 </Project>

--- a/ClosedXML.Report/Options/PivotTag.cs
+++ b/ClosedXML.Report/Options/PivotTag.cs
@@ -46,8 +46,8 @@ namespace ClosedXML.Report.Options
             var dataTags = List.GetAll<DataPivotTag>().OrderBy(t => t.Column);
 
             var pivotTag = fields.FirstOrDefault(t => t.Name.ToLower() == "pivot") ?? this;
-            var (tableName, dstSheet, dstCell) = GetDestination(pivotTag, wb, pageTags);
-            var pt = CreatePivot(pivotTag, context, dstSheet, tableName, dstCell);
+            var destination =  GetDestination(pivotTag, wb, pageTags);
+            var pt = CreatePivot(pivotTag, context, destination);
 
             foreach (var optionTag in pageTags)
             {
@@ -159,7 +159,7 @@ namespace ClosedXML.Report.Options
             */
         }
 
-        private (string, IXLWorksheet, IXLCell) GetDestination(PivotTag pivot, XLWorkbook wb, IEnumerable<OptionTag> pageTags)
+        private XLPivotTableDestination GetDestination(PivotTag pivot, XLWorkbook wb, IEnumerable<OptionTag> pageTags)
         {
             string tableName = pivot.GetParameter("name");
             if (tableName.IsNullOrWhiteSpace()) tableName = "PivotTable";
@@ -183,13 +183,13 @@ namespace ClosedXML.Report.Options
                 dstSheet = wb.AddWorksheet(tableName);
                 dstCell = dstSheet.Cell(pageTags.Count() + 3, 2);
             }
-            return (tableName, dstSheet, dstCell);
+            return new XLPivotTableDestination(tableName, dstSheet, dstCell);
         }
 
-        private IXLPivotTable CreatePivot(PivotTag pivot, ProcessingContext context, IXLWorksheet targetSheet, string tableName, IXLCell targetCell)
+        private IXLPivotTable CreatePivot(PivotTag pivot, ProcessingContext context, XLPivotTableDestination destination)
         {
             IXLRange srcRange = context.Range.Offset(-1, 1, context.Range.RowCount(), context.Range.ColumnCount() - 1);
-            var pt = targetSheet.PivotTables.AddNew(tableName, targetCell, srcRange);
+            var pt = destination.TargetWorksheet.PivotTables.AddNew(destination.TableName, destination.TargetCell, srcRange);
             pt.MergeAndCenterWithLabels = pivot.HasParameter("MergeLabels");
             pt.ShowExpandCollapseButtons = pivot.HasParameter("ShowButtons");
             pt.ClassicPivotTableLayout = !pivot.HasParameter("TreeLayout");
@@ -207,6 +207,20 @@ namespace ClosedXML.Report.Options
         private static string GetColumnName(ProcessingContext context, OptionTag tag)
         {
             return context.Range.FirstRow().RowAbove().Cell(tag.Column).GetString();
+        }
+
+        private struct XLPivotTableDestination
+        {
+            public XLPivotTableDestination(string tableName, IXLWorksheet targetWorksheet, IXLCell targetCell)
+            {
+                TableName = tableName;
+                TargetWorksheet = targetWorksheet;
+                TargetCell = targetCell;
+            }
+
+            public string TableName { get; }
+            public IXLWorksheet TargetWorksheet { get; }
+            public IXLCell TargetCell { get; }
         }
     }
 


### PR DESCRIPTION
Same as #92 for `release_0.1` branch: while 0.2 is in the beta state I would like to release version 0.1.2.