### PR TITLE
increased subrange tests execution speed - second attempt

### DIFF
--- a/ClosedXML.Report/Excel/XlExtensions.cs
+++ b/ClosedXML.Report/Excel/XlExtensions.cs
@@ -208,6 +208,13 @@ namespace ClosedXML.Report.Excel
             return (string)method.Invoke(cell, new object[] { value });
         }
 
+        internal static string GetInnerText(this IXLCell cell)
+        {
+            var type = cell.GetType();
+            var property = type.GetProperty("InnerText", BindingFlags.Instance | BindingFlags.Public);
+            return (string)property.GetValue(cell, null);
+        }
+
         internal static void CopyRelative(this IXLConditionalFormat format, IXLRangeBase fromRange, IXLRangeBase toRange, bool expand)
         {
             foreach (var sourceFmtRange in format.Ranges)

--- a/ClosedXML.Report/Excel/XlExtensions.cs
+++ b/ClosedXML.Report/Excel/XlExtensions.cs
@@ -208,11 +208,13 @@ namespace ClosedXML.Report.Excel
             return (string)method.Invoke(cell, new object[] { value });
         }
 
+        private static PropertyInfo _xlCellInnerText;
         internal static string GetInnerText(this IXLCell cell)
         {
-            var type = cell.GetType();
-            var property = type.GetProperty("InnerText", BindingFlags.Instance | BindingFlags.Public);
-            return (string)property.GetValue(cell, null);
+            _xlCellInnerText = _xlCellInnerText ??
+                               cell.GetType()
+                                   .GetProperty("InnerText", BindingFlags.Instance | BindingFlags.Public);
+            return (string)_xlCellInnerText.GetValue(cell, null);
         }
 
         internal static void CopyRelative(this IXLConditionalFormat format, IXLRangeBase fromRange, IXLRangeBase toRange, bool expand)

--- a/ClosedXML.Report/FormulaEvaluator.cs
+++ b/ClosedXML.Report/FormulaEvaluator.cs
@@ -1,9 +1,8 @@
-﻿using System;
+﻿using ClosedXML.Report.Utils;
+using System;
 using System.Collections.Generic;
-using System.Dynamic;
 using System.Globalization;
 using System.Linq;
-using System.Linq.Dynamic.Core;
 using System.Linq.Expressions;
 using System.Text.RegularExpressions;
 
@@ -59,7 +58,7 @@ namespace ClosedXML.Report
                 var parameters = pars.Select(p=>p.ParameterExpression).ToArray();
                 try
                 {
-                    lambda = DynamicExpressionParser.ParseLambda(parameters, typeof(object), expression, _variables).Compile();
+                    lambda = XLDynamicExpressionParser.ParseLambda(parameters, typeof(object), expression, _variables).Compile();
                 }
                 catch (ArgumentException)
                 {

--- a/ClosedXML.Report/Options/SummaryFuncTag.cs
+++ b/ClosedXML.Report/Options/SummaryFuncTag.cs
@@ -1,6 +1,6 @@
-﻿using System.Linq.Dynamic.Core;
-using System.Linq.Expressions;
+﻿using System.Linq.Expressions;
 using ClosedXML.Report.Excel;
+using ClosedXML.Report.Utils;
 
 namespace ClosedXML.Report.Options
 {
@@ -33,7 +33,7 @@ namespace ClosedXML.Report.Options
                 func.GetExpression = type =>
                 {
                     var par = Expression.Parameter(type, "item");
-                    return DynamicExpressionParser.ParseLambda(new[] {par}, null, GetParameter("Over"));
+                    return XLDynamicExpressionParser.ParseLambda(new[] {par}, null, GetParameter("Over"));
                 };
             func.DataSource = DataSource;
             return func;

--- a/ClosedXML.Report/Utils/XLDynamicExpressionParser.cs
+++ b/ClosedXML.Report/Utils/XLDynamicExpressionParser.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Dynamic.Core;
+using System.Linq.Dynamic.Core.CustomTypeProviders;
+using System.Linq.Expressions;
+using System.Text;
+
+namespace ClosedXML.Report.Utils
+{
+    internal static class XLDynamicExpressionParser
+    {
+        /// <summary>
+        /// A wrapper for <see cref="DynamicExpressionParser.ParseLambda"/> providing custom parsing config.
+        /// </summary>
+        /// <param name="parameters">A array from ParameterExpressions.</param>
+        /// <param name="resultType">Type of the result. If not specified, it will be generated dynamically.</param>
+        /// <param name="expression">The expression.</param>
+        /// <param name="values">An object array that contains zero or more objects which are used as replacement values.</param>
+        /// <returns>The generated <see cref="T:System.Linq.Expressions.LambdaExpression" /></returns>
+        public static LambdaExpression ParseLambda(
+            ParameterExpression[] parameters,
+            Type resultType,
+            string expression,
+            params object[] values)
+        {
+            var config = new ParsingConfig()
+            {
+                CustomTypeProvider = new XLDynamicLinqCustomTypeProvider()
+            };
+
+            return DynamicExpressionParser.ParseLambda(config, parameters, resultType, expression, values);
+        }
+
+        private  class XLDynamicLinqCustomTypeProvider : DefaultDynamicLinqCustomTypeProvider
+        {
+            private static HashSet<Type> _customTypesCache;
+
+            public override HashSet<Type> GetCustomTypes()
+            {
+                if (_customTypesCache != null)
+                    return _customTypesCache;
+
+                _customTypesCache = base.GetCustomTypes();
+                return _customTypesCache;
+            }
+        }
+    }
+}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,6 +48,11 @@ before_build:
 build:
   verbosity: minimal
 
+test:
+  assemblies:
+    only:
+      - tests/ClosedXML.Report.Tests/bin/%CONFIGURATION%/*/ClosedXML.Report.Tests.dll
+
 configuration:
 - Release
 - Release.Signed

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,10 +48,8 @@ before_build:
 build:
   verbosity: minimal
 
-test:
-  assemblies:
-    only:
-      - tests/ClosedXML.Report.Tests/bin/%CONFIGURATION%/*/ClosedXML.Report.Tests.dll
+test_script:
+  - dotnet test tests/ClosedXML.Report.Tests
 
 configuration:
 - Release

--- a/tests/ClosedXML.Report.Tests/FormulaEvaluatorTests.cs
+++ b/tests/ClosedXML.Report.Tests/FormulaEvaluatorTests.cs
@@ -1,10 +1,9 @@
-﻿using System.Collections.Generic;
+﻿using ClosedXML.Report.Utils;
+using System.Collections.Generic;
 using System.Linq;
-using System.Linq.Dynamic.Core;
 using System.Linq.Dynamic.Core.Exceptions;
 using System.Linq.Expressions;
 using FluentAssertions;
-using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace ClosedXML.Report.Tests
@@ -33,7 +32,7 @@ namespace ClosedXML.Report.Tests
             }.AsEnumerable();
 
             string query = "customers.Where(c => c.Id == 1).OrderBy(c=> c.Name)";
-            var lambda = DynamicExpressionParser.ParseLambda(new [] {Expression.Parameter(customers.GetType(), "customers")}, null, query);
+            var lambda = XLDynamicExpressionParser.ParseLambda(new [] {Expression.Parameter(customers.GetType(), "customers")}, null, query);
             var dlg = lambda.Compile();
             dlg.DynamicInvoke(customers).Should().BeAssignableTo<IEnumerable<Customer>>();
             ((IEnumerable<Customer>) dlg.DynamicInvoke(customers)).Should().HaveCount(1);

--- a/tests/ClosedXML.Report.Tests/GlobalTestSetup.cs
+++ b/tests/ClosedXML.Report.Tests/GlobalTestSetup.cs
@@ -1,0 +1,13 @@
+﻿namespace ClosedXML.Report.Tests
+{
+    class GlobalTestSetup
+    {
+        public GlobalTestSetup()
+        {
+            //Warm-up DynamicExpressionParser
+            var evaluator = new FormulaEvaluator();
+            evaluator.AddVariable("item", "warm-up");
+            evaluator.Evaluate("&={{item.Length}}");
+        }
+    }
+}

--- a/tests/ClosedXML.Report.Tests/XlsxTemplateTestsBase.cs
+++ b/tests/ClosedXML.Report.Tests/XlsxTemplateTestsBase.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using ClosedXML.Excel;
+using ClosedXML.Report.Excel;
 using FluentAssertions;
 //using JetBrains.Profiler.Windows.Api;
 using Xunit.Abstractions;
@@ -134,7 +135,7 @@ namespace ClosedXML.Report.Tests
                 var actualCell = actual.Cell(address);
                 bool cellsAreEqual = true;
 
-                if (actualCell.FormulaA1 != expectedCell.FormulaA1)
+                if (actualCell.FormulaA1 != expectedCell.FormulaA1 && actualCell.GetInnerText() != expectedCell.GetInnerText())
                 {
                     messages.Add($"Cell values are not equal starting from {address}");
                     cellsAreEqual = false;

--- a/tests/ClosedXML.Report.Tests/XlsxTemplateTestsBase.cs
+++ b/tests/ClosedXML.Report.Tests/XlsxTemplateTestsBase.cs
@@ -134,7 +134,7 @@ namespace ClosedXML.Report.Tests
                 var actualCell = actual.Cell(address);
                 bool cellsAreEqual = true;
 
-                if (actualCell.Value?.ToString() != expectedCell.Value?.ToString())
+                if (actualCell.FormulaA1 != expectedCell.FormulaA1)
                 {
                     messages.Add($"Cell values are not equal starting from {address}");
                     cellsAreEqual = false;

--- a/tests/ClosedXML.Report.Tests/XlsxTemplateTestsBase.cs
+++ b/tests/ClosedXML.Report.Tests/XlsxTemplateTestsBase.cs
@@ -135,7 +135,7 @@ namespace ClosedXML.Report.Tests
                 var actualCell = actual.Cell(address);
                 bool cellsAreEqual = true;
 
-                if (actualCell.FormulaA1 != expectedCell.FormulaA1 && actualCell.GetInnerText() != expectedCell.GetInnerText())
+                if (!expectedCell.HasFormula && !actualCell.HasFormula && actualCell.GetInnerText() != expectedCell.GetInnerText())
                 {
                     messages.Add($"Cell values are not equal starting from {address}");
                     cellsAreEqual = false;


### PR DESCRIPTION
Value evaluation is slow. Replacing Value to Formula and InnerText increase tests execution speed.