### PR TITLE
Dispose VernoStringReader

### DIFF
--- a/ClosedXML.Report/Options/TagsEvaluator.cs
+++ b/ClosedXML.Report/Options/TagsEvaluator.cs
@@ -39,13 +39,17 @@ namespace ClosedXML.Report.Options
 
         private OptionTag ParseTag(string str)
         {
-            var reader = new VernoStringReader(str);
-            var name = reader.ReadWord();
-            
-            Dictionary<string, string> dictionary = new Dictionary<string, string>();
-            foreach (var pair in reader.ReadNamedValues(" ", "="))
+            string name;
+            Dictionary<string, string> dictionary;
+            using (var reader = new VernoStringReader(str))
             {
-                dictionary.Add(pair.Key.ToLower(), pair.Value);
+                name = reader.ReadWord();
+            
+                dictionary = new Dictionary<string, string>();
+                foreach (var pair in reader.ReadNamedValues(" ", "="))
+                {
+                    dictionary.Add(pair.Key.ToLower(), pair.Value);
+                }
             }
 
             return TagsRegister.CreateOption(name, dictionary);


### PR DESCRIPTION
Simply added using() statement for reader = new VernoStringReader(str);

Also wanted to ask about OnlyValuesTag.cs
Why variables are assigned to itself? (3 lines marked with comment)
```
            // whole worksheet or range
            if (IsSpecialRangeCell(xlCell) || cellAddr == "A2")
            {
                range.CellsUsed(i => i.HasFormula)
                    .ForEach(c => c.Value = c.Value);// variable is assigned to itself
            }
            // range column
            else if (RangeOptionsRow != null)
            {
                var cmln = xlCell.Address.ColumnNumber - Range.RangeAddress.FirstAddress.ColumnNumber + 1;
                context.Range.Column(cmln)
                    .CellsUsed(i => i.HasFormula)
                    .ForEach(c => c.Value = c.Value);// variable is assigned to itself
            }
            // one cell
            else if (Cell.CellType == TemplateCellType.Formula)
            {
                xlCell.Value = xlCell.Value;// variable is assigned to itself
            }
```