### PR TITLE
Test inner range null reference exception.

### DIFF
--- a/tests/ClosedXML.Report.Tests/TempSheetBufferTests.cs
+++ b/tests/ClosedXML.Report.Tests/TempSheetBufferTests.cs
@@ -45,5 +45,35 @@ namespace ClosedXML.Report.Tests
                 ws.Cell("B4").Value.Should().Be("");
             }
         }
+
+        [Fact]
+        public void InnerRange()
+        {
+            using (var wb = new XLWorkbook())
+            {
+                // Arrange.
+                const string rangeName = "List";
+                const string innerRangeName = "CustomTotals";
+                const string totalsName = "Totals";
+                var list = new List<string> { "Value1", "Value2" };
+                var ws = wb.AddWorksheet("Sheet1");
+                ws.Cell("B1").Value = "Header";
+                ws.Range("A2:C3").AddToNamed(rangeName);
+                ws.Cell("B2").Value = "{{index+1}}";
+                ws.Cell("C2").Value = "{{item}}";
+                ws.Cell("B3").Value = totalsName;
+                ws.Range("C3:C3").AddToNamed(innerRangeName);
+
+                // Act.
+                var template = new XLTemplate(wb);
+                template.AddVariable(rangeName, list);
+                template.AddVariable(innerRangeName, list.Count);
+                template.Generate();
+
+                // Assert.
+                ws.Cell("B4").Value.Should().Be(totalsName);
+                ws.Cell("C4").Value.Should().Be(list.Count);
+            }
+        }
     }
 }


### PR DESCRIPTION
I have upgraded to latest versions ClosedXML.Signed (from 0.95.0-beta1 to 0.95.3) and ClosedXML.Report (from 0.2.0-beta1 to 0.2.1). One of my test fails on generation of template with NRE with this stack trace:
```
2020-06-10T05:52:34.4899081Z       System.NullReferenceException : Object reference not set to an instance of an object
2020-06-10T05:52:34.4902904Z       Stack Trace:
2020-06-10T05:52:34.4903680Z           at ClosedXML.Excel.XLCell.CopyValuesFrom (ClosedXML.Excel.XLCell source) [0x00000] in <97c12c3cb9f34e07a7b9d562cbce5f3c>:0 
2020-06-10T05:52:34.4904626Z           at ClosedXML.Excel.XLCell.CopyFromInternal (ClosedXML.Excel.XLCell otherCell, ClosedXML.Excel.XLCellCopyOptions options) [0x00013] in <97c12c3cb9f34e07a7b9d562cbce5f3c>:0 
2020-06-10T05:52:34.4905631Z           at ClosedXML.Excel.XLCell.CopyFrom (ClosedXML.Excel.IXLCell otherCell, ClosedXML.Excel.XLCellCopyOptions options) [0x00007] in <97c12c3cb9f34e07a7b9d562cbce5f3c>:0 
2020-06-10T05:52:34.4906799Z           at ClosedXML.Excel.XLCell.CopyFrom (ClosedXML.Excel.IXLCell otherCell) [0x00000] in <97c12c3cb9f34e07a7b9d562cbce5f3c>:0 
2020-06-10T05:52:34.4907695Z           at ClosedXML.Report.Excel.TempSheetBuffer.WriteValue (System.Object value, ClosedXML.Excel.IXLCell settingCell) [0x00018] in <76c47c034f524695b27ad1ce94c1a128>:0 
2020-06-10T05:52:34.4909001Z           at ClosedXML.Report.RangeTemplate.RenderCell (ClosedXML.Report.FormulaEvaluator evaluator, ClosedXML.Report.TemplateCell cell, ClosedXML.Report.Parameter[] pars) [0x00152] in <76c47c034f524695b27ad1ce94c1a128>:0 
2020-06-10T05:52:34.4910065Z           at ClosedXML.Report.RangeTemplate.VerticalTable (System.Object[] items, ClosedXML.Report.FormulaEvaluator evaluator) [0x001b0] in <76c47c034f524695b27ad1ce94c1a128>:0 
2020-06-10T05:52:34.4911167Z           at ClosedXML.Report.RangeTemplate.Generate (System.Object[] items) [0x0007f] in <76c47c034f524695b27ad1ce94c1a128>:0 
2020-06-10T05:52:34.4912201Z           at ClosedXML.Report.RangeInterpreter.EvaluateValues (ClosedXML.Excel.IXLRange range, ClosedXML.Report.Parameter[] pars) [0x0039d] in <76c47c034f524695b27ad1ce94c1a128>:0 
2020-06-10T05:52:34.4913113Z           at ClosedXML.Report.RangeInterpreter.Evaluate (ClosedXML.Excel.IXLRange range) [0x0001c] in <76c47c034f524695b27ad1ce94c1a128>:0 
2020-06-10T05:52:34.4913880Z           at ClosedXML.Report.XLTemplate.Generate () [0x00055] in <76c47c034f524695b27ad1ce94c1a128>:0 
2020-06-10T05:52:34.4915167Z           at Iis.Eais.Payments.Reporting.ReportBuilders.OtchetPoPredostavleniiuMerSotcialnoiPodderzhkiGrazhdanamPodvergshimsiaVozdeistviiuRadiatciiBuilder.FormExcel (Iis.Eais.Payments.Reporting.DTO.ExportOtchetPoPredostavleniiuMerSotcialnoiPodderzhkiGrazhdanamPodvergshimsiaVozdeistviiuRadiatciiBuilderParameters param) [0x00763] in <d22116a551c040f681f2967d88b9abf6>:0 
2020-06-10T05:52:34.4916982Z           at Iis.Eais.Payments.Reporting.ReportBuilders.OtchetPoPredostavleniiuMerSotcialnoiPodderzhkiGrazhdanamPodvergshimsiaVozdeistviiuRadiatciiBuilder.Build (Iis.Eais.Payments.Reporting.DTO.ExportOtchetPoPredostavleniiuMerSotcialnoiPodderzhkiGrazhdanamPodvergshimsiaVozdeistviiuRadiatciiBuilderParameters param, System.Threading.CancellationToken ct) [0x00008] in <d22116a551c040f681f2967d88b9abf6>:0 
2020-06-10T05:52:34.4918542Z           at Iis.Eais.Reporting.IntegratedTests.Extensions.ReportBuilderExtensions.BuildWithTimer[TP] (Iis.Eais.Common.Interfaces.IReportBuilder`1[T] instance, TP param, Xunit.Abstractions.ITestOutputHelper output) [0x00087] in <2ddf1e8203e249f592b217c625448cde>:0 
2020-06-10T05:52:34.4919823Z           at Iis.Eais.Reporting.IntegratedTests.Build.PaymentsBuildTests.OtchetPoPredostavleniiuMerSotcialnoiPodderzhkiGrazhdanamPodvergshimsiaVozdeistviiuRadiatciiBuilderShouldBuild () [0x000d4] in <2ddf1e8203e249f592b217c625448cde>:0 
2020-06-10T05:52:34.4920891Z           at System.Runtime.CompilerServices.AsyncMethodBuilderCore+<>c.<ThrowAsync>b__7_0 (System.Object state) [0x00000] in <d2ec5c92492f4d6ba8c422bdf574b786>:0 
```

Adding unit test to the other side of an issue: https://github.com/ClosedXML/ClosedXML/pull/1461