### PR TITLE
Fix issues with inability to bind ranges to the entity referenced by alias or to the root entity properties

### DIFF
--- a/ClosedXML.Report/FormulaEvaluator.cs
+++ b/ClosedXML.Report/FormulaEvaluator.cs
@@ -1,4 +1,5 @@
 ﻿using ClosedXML.Report.Utils;
+using DocumentFormat.OpenXml.Bibliography;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -27,6 +28,20 @@ namespace ClosedXML.Report
                 formula = formula.Replace(expr, ObjToString(val));
             }
             return formula;
+        }
+
+        public bool TryEvaluate(string formula, out object result, params Parameter[] pars)
+        {
+            try
+            {
+                result = Evaluate(formula, pars);
+                return true;
+            }
+            catch
+            {
+                result = null;
+                return false;
+            }
         }
 
         public void AddVariable(string name, object value)


### PR DESCRIPTION
Hi @b0bi79, long time no see!

I've been trying to generate reports with ClosedXML.Report and found an issue with binding ranges to the properties of the input object.

Consider we have a `Parent` object with a collection of `Child` entities, and we want to output some properties of the parent and create a table for children.

If we create a named range `{{Children}}` and then pass the variable using
```
template.AddVariable(parent);
```
it works fine. But if instead, we want to pass the variable as 
```
template.AddVariable("Model", parent);
```
and name the range `Model_Children` - the generation fails due to the name is not recognized.

Moreover, it turned out, if we add another property (say `Container`) to the `Parent` class, that also have a list of children and try to bind the range to that list, it fails in both cases - either if we specify the alias or not.

Without alias:
![image](https://user-images.githubusercontent.com/19576939/89098517-761ab280-d3f9-11ea-929d-7a473a4a9a7e.png)

With alias:
![image](https://user-images.githubusercontent.com/19576939/89098524-8af74600-d3f9-11ea-9467-b8bb47bd76ef.png)

Expected result:
![image](https://user-images.githubusercontent.com/19576939/89098540-ae21f580-d3f9-11ea-9938-90ebcac984d6.png)

Repro:
```
    class Program
    {
        static void Main(string[] args)
        {
            var entity = new Parent();

            /*--------*/

            var wbTemplate1 = new XLWorkbook();
            var ws1 = wbTemplate1.AddWorksheet("Sheet1");

            ws1.Cell("B1").Value = "{{Name}}";
            ws1.Cell("B2").Value = "Children:";
            ws1.Cell("B3").Value = "{{item.ChildName}}";
            ws1.Range("A3:B4").AddToNamed("Children");
            ws1.Cell("D2").Value = "Items in container:";
            ws1.Cell("E2").Value = "{{item.ChildName}}";
            ws1.Range("E2:E2").AddToNamed("Container_ItemsInContainer");

            var template1 = new XLTemplate(wbTemplate1);
            template1.AddVariable(entity);
            template1.Generate();
            template1.SaveAs("WithoutAlias.xlsx");

            /*--------*/

            var wbTemplate2 = new XLWorkbook();
            var ws2 = wbTemplate2.AddWorksheet("Sheet1");

            ws2.Cell("B1").Value = "{{Model.Name}}";
            ws2.Cell("B2").Value = "Children:";
            ws2.Cell("B3").Value = "{{item.ChildName}}";
            ws2.Range("A3:B4").AddToNamed("Model_Children");
            ws2.Cell("D2").Value = "Items in container:";
            ws2.Cell("E2").Value = "{{item.ChildName}}";
            ws2.Range("E2:E2").AddToNamed("Model_Container_ItemsInContainer");

            var template2 = new XLTemplate(wbTemplate2);
            template2.AddVariable("Model", entity);
            template2.Generate();
            template2.SaveAs("WithAlias.xlsx");

            /*--------*/
        }
    }

    public class Parent
    {
        public string Name => "Parent Name";
        public Container Container = new Container();
        public List<Child> Children { get; } = new List<Child>
        {
            new Child("Child 1"),
            new Child("Child 2"),
            new Child("Child 3"),
        };
    }

    public class Child
    {
        public string ChildName { get; }

        public Child(string childName)
        {
            ChildName = childName;
        }
    }

    public class Container
    {
        public List<Child> ItemsInContainer { get; } = new List<Child>
        {
            new Child("Item in container 1"),
            new Child("Item in container 2"),
            new Child("Item in container 3"),
        };
    }
```

This PR fixes this issue.