### PR TITLE
Update to ClosedXML version 0.96; drop ClosedXML.Report.Signed

### DIFF
--- a/ClosedXML.Report.sln
+++ b/ClosedXML.Report.sln
@@ -14,20 +14,15 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
-		Release.Signed|Any CPU = Release.Signed|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{DEF4A219-D1CF-42A2-A5AC-FE7F2F005AB0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{DEF4A219-D1CF-42A2-A5AC-FE7F2F005AB0}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{DEF4A219-D1CF-42A2-A5AC-FE7F2F005AB0}.Release.Signed|Any CPU.ActiveCfg = Release.Signed|Any CPU
-		{DEF4A219-D1CF-42A2-A5AC-FE7F2F005AB0}.Release.Signed|Any CPU.Build.0 = Release.Signed|Any CPU
 		{DEF4A219-D1CF-42A2-A5AC-FE7F2F005AB0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DEF4A219-D1CF-42A2-A5AC-FE7F2F005AB0}.Release|Any CPU.Build.0 = Release|Any CPU
 		{D529A371-3AEA-4D02-9A0D-308A6276D411}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D529A371-3AEA-4D02-9A0D-308A6276D411}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{D529A371-3AEA-4D02-9A0D-308A6276D411}.Release.Signed|Any CPU.ActiveCfg = Release.Signed|Any CPU
-		{D529A371-3AEA-4D02-9A0D-308A6276D411}.Release.Signed|Any CPU.Build.0 = Release.Signed|Any CPU
 		{D529A371-3AEA-4D02-9A0D-308A6276D411}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D529A371-3AEA-4D02-9A0D-308A6276D411}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection

--- a/ClosedXML.Report/ClosedXML.Report.csproj
+++ b/ClosedXML.Report/ClosedXML.Report.csproj
@@ -60,9 +60,9 @@
 
   <ItemGroup>
     <PackageReference Include="ClosedXML.Signed" Version="0.95.0" Condition="'$(Configuration)'=='Release.Signed'" />
-    <PackageReference Include="ClosedXML" Version="0.95.4" Condition="'$(Configuration)'!='Release.Signed'" />
+    <PackageReference Include="ClosedXML" Version="0.96.0" Condition="'$(Configuration)'!='Release.Signed'" />
     <PackageReference Include="morelinq" Version="3.3.2" />
-    <PackageReference Include="System.Linq.Dynamic.Core" Version="1.2.18" />
+    <PackageReference Include="System.Linq.Dynamic.Core" Version="1.2.20" />
   </ItemGroup>
 
 </Project>

--- a/ClosedXML.Report/ClosedXML.Report.csproj
+++ b/ClosedXML.Report/ClosedXML.Report.csproj
@@ -11,7 +11,6 @@
     <RepositoryUrl>https://github.com/ClosedXML/ClosedXML.Report</RepositoryUrl>
     <Authors>Alexey Rozhkov</Authors>
     <Copyright>MIT</Copyright>
-    <Version>0.3.0.0</Version>
     <Product>ClosedXML.Report</Product>
     <PackageReleaseNotes>See https://github.com/ClosedXML/ClosedXML.Report/releases/tag/$(productVersion)</PackageReleaseNotes>
     <Description>ClosedXML.Report is a tool for report generation and data analysis in .NET applications through the use of Microsoft Excel. ClosedXML.Report is a .NET-library for report generation Microsoft Excel without requiring Excel to be installed on the machine that's running the code.</Description>

--- a/ClosedXML.Report/ClosedXML.Report.csproj
+++ b/ClosedXML.Report/ClosedXML.Report.csproj
@@ -11,7 +11,7 @@
     <RepositoryUrl>https://github.com/ClosedXML/ClosedXML.Report</RepositoryUrl>
     <Authors>Alexey Rozhkov</Authors>
     <Copyright>MIT</Copyright>
-    <Version>0.2.0.0</Version>
+    <Version>0.3.0.0</Version>
     <Product>ClosedXML.Report</Product>
     <PackageReleaseNotes>See https://github.com/ClosedXML/ClosedXML.Report/releases/tag/$(productVersion)</PackageReleaseNotes>
     <Description>ClosedXML.Report is a tool for report generation and data analysis in .NET applications through the use of Microsoft Excel. ClosedXML.Report is a .NET-library for report generation Microsoft Excel without requiring Excel to be installed on the machine that's running the code.</Description>

--- a/ClosedXML.Report/ClosedXML.Report.csproj
+++ b/ClosedXML.Report/ClosedXML.Report.csproj
@@ -5,7 +5,7 @@
     <LangVersion>Latest</LangVersion>
     <AssemblyName>ClosedXML.Report</AssemblyName>
     <PackageId>ClosedXML.Report</PackageId>
-    <Configurations>Debug;Release;Release.Signed</Configurations>
+    <Configurations>Debug;Release</Configurations>
     <PackageLicenseUrl></PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/ClosedXML/ClosedXML.Report</PackageProjectUrl>
     <RepositoryUrl>https://github.com/ClosedXML/ClosedXML.Report</RepositoryUrl>
@@ -30,22 +30,14 @@
     <!-- Optional: Build symbol package (.snupkg) to distribute the PDB containing Source Link -->
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-  </PropertyGroup>
-  
-  <PropertyGroup Condition="'$(Configuration)'=='Release.Signed'">
-    <PackageId>ClosedXML.Report.Signed</PackageId>
-    <OutputPath>bin\Release.Signed\</OutputPath>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Optimize>true</Optimize>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>ClosedXML.Report.snk</AssemblyOriginatorKeyFile>
-    <DefineConstants>$(DefineConstants);RELEASE;STRONGNAME</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
-  
+
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
   </PropertyGroup>
@@ -59,8 +51,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClosedXML.Signed" Version="0.95.0" Condition="'$(Configuration)'=='Release.Signed'" />
-    <PackageReference Include="ClosedXML" Version="0.96.0" Condition="'$(Configuration)'!='Release.Signed'" />
+    <PackageReference Include="ClosedXML" Version="0.96.0" />
     <PackageReference Include="morelinq" Version="3.3.2" />
     <PackageReference Include="System.Linq.Dynamic.Core" Version="1.2.20" />
   </ItemGroup>

--- a/ClosedXML.Report/Properties/AssemblyInfo.cs
+++ b/ClosedXML.Report/Properties/AssemblyInfo.cs
@@ -1,8 +1,4 @@
 ﻿using System.Runtime.CompilerServices;
 
 // Tests accessing
-#if STRONGNAME
 [assembly: InternalsVisibleTo("ClosedXML.Report.Tests, PublicKey=00240000048000009400000006020000002400005253413100040000010001002b89cad160592ac2770c3651edc6b07038b8d00544858ab632e767ba4052afbdfb4c7fc18deb924b3aea7ecceca8b394e2b14cb9d98e780c8e6159dcb62da75d99f1e1e583ad078ac4836275c58c0cbb786ed317a9a6ac7fa70a9355a88bc41b9f8cf5d5547020c6f02eca4ecf01e1db5d84c6e6788b103064cdd78e14a3c0b2")]
-#else
-[assembly: InternalsVisibleTo("ClosedXML.Report.Tests")]
-#endif

--- a/ClosedXML.Report/RangeInterpreter.cs
+++ b/ClosedXML.Report/RangeInterpreter.cs
@@ -147,24 +147,24 @@ namespace ClosedXML.Report
 
                 if (cell.HasComment)
                 {
-                    var comment = EvalString(cell.Comment.Text);
-                    cell.Comment.ClearText();
-                    cell.Comment.AddText(comment);
+                    var comment = EvalString(cell.GetComment().Text);
+                    cell.GetComment().ClearText();
+                    cell.GetComment().AddText(comment);
                 }
 
                 if (cell.HasHyperlink)
                 {
-                    if (cell.Hyperlink.IsExternal)
-                        cell.Hyperlink.ExternalAddress = new Uri(EvalString(cell.Hyperlink.ExternalAddress.ToString()));
+                    if (cell.GetHyperlink().IsExternal)
+                        cell.GetHyperlink().ExternalAddress = new Uri(EvalString(cell.GetHyperlink().ExternalAddress.ToString()));
                     else
-                        cell.Hyperlink.InternalAddress = EvalString(cell.Hyperlink.InternalAddress);
+                        cell.GetHyperlink().InternalAddress = EvalString(cell.GetHyperlink().InternalAddress);
                 }
 
                 if (cell.HasRichText)
                 {
-                    var richText = EvalString(cell.RichText.Text);
-                    cell.RichText.ClearText();
-                    cell.RichText.AddText(richText);
+                    var richText = EvalString(cell.GetRichText().Text);
+                    cell.GetRichText().ClearText();
+                    cell.GetRichText().AddText(richText);
                 }
             }
 

--- a/ClosedXML.Report/RangeTemplate.cs
+++ b/ClosedXML.Report/RangeTemplate.cs
@@ -311,24 +311,24 @@ namespace ClosedXML.Report
 
             if (xlCell.HasComment)
             {
-                var comment = EvalString(xlCell.Comment.Text);
-                xlCell.Comment.ClearText();
-                xlCell.Comment.AddText(comment);
+                var comment = EvalString(xlCell.GetComment().Text);
+                xlCell.GetComment().ClearText();
+                xlCell.GetComment().AddText(comment);
             }
 
             if (xlCell.HasHyperlink)
             {
-                if (xlCell.Hyperlink.IsExternal)
-                    xlCell.Hyperlink.ExternalAddress = new Uri(EvalString(xlCell.Hyperlink.ExternalAddress.ToString()));
+                if (xlCell.GetHyperlink().IsExternal)
+                    xlCell.GetHyperlink().ExternalAddress = new Uri(EvalString(xlCell.GetHyperlink().ExternalAddress.ToString()));
                 else
-                    xlCell.Hyperlink.InternalAddress = EvalString(xlCell.Hyperlink.InternalAddress);
+                    xlCell.GetHyperlink().InternalAddress = EvalString(xlCell.GetHyperlink().InternalAddress);
             }
 
             if (xlCell.HasRichText)
             {
-                var richText = EvalString(xlCell.RichText.Text);
-                xlCell.RichText.ClearText();
-                xlCell.RichText.AddText(richText);
+                var richText = EvalString(xlCell.GetRichText().Text);
+                xlCell.GetRichText().ClearText();
+                xlCell.GetRichText().AddText(richText);
             }
         }
 

--- a/README.md
+++ b/README.md
@@ -28,10 +28,6 @@ To install ClosedXML.Report, run the following command in the Package Manager Co
 ```
 PM> Install-Package ClosedXML.Report
 ```
-or if you have a signed assembly, then use:
-```
-PM> Install-Package ClosedXML.Report.Signed
-```
 
 ## Features
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,6 @@ init:
       $env:fileVersion = $env:APPVEYOR_BUILD_VERSION -replace '(\d+)\.(\d+)\.([^.]+)\.(\d+)', '$1.$2.999.$4'
       $env:productVersion = $env:fileVersion
     }
-    $env:signed = $env:CONFIGURATION.Substring(7)
     
     Update-AppveyorBuild -Version $env:fileVersion
     
@@ -49,7 +48,6 @@ dotnet_csproj:
 # platform: Any CPU
 configuration:
 - Release
-- Release.Signed
 
 before_build:
   - cmd: nuget update -self
@@ -62,7 +60,7 @@ test_script:
   - dotnet test tests/ClosedXML.Report.Tests
 after_build:
   - cd ClosedXML.Report/bin/%CONFIGURATION%/
-  - 7z a ClosedXML.Report%signed%_%productVersion%.zip */ClosedXML.Report.dll
+  - 7z a ClosedXML.Report_%productVersion%.zip */ClosedXML.Report.dll
   - cd ../../../
 
 artifacts:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 # common configuration for ALL branches
 
-version: 0.3.0.{build}
+version: 0.2.5.{build}
 
 pull_requests:
   do_not_increment_build_number: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 # common configuration for ALL branches
 
-version: 0.2.0.{build}
+version: 0.3.0.{build}
 
 pull_requests:
   do_not_increment_build_number: true

--- a/tests/ClosedXML.Report.Tests/ClosedXML.Report.Tests.csproj
+++ b/tests/ClosedXML.Report.Tests/ClosedXML.Report.Tests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net462;net6.0</TargetFrameworks>
     <LangVersion>Latest</LangVersion>
-    <Configurations>Debug;Release;Release.Signed</Configurations>
+    <Configurations>Debug;Release</Configurations>
     <PackageLicenseUrl>https://github.com/ClosedXML/ClosedXML.Report/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/ClosedXML/ClosedXML.Report</PackageProjectUrl>
     <RepositoryUrl>https://github.com/ClosedXML/ClosedXML.Report</RepositoryUrl>
@@ -10,20 +10,15 @@
     <Authors>Alexey Rozhkov</Authors>
     <Copyright>MIT</Copyright>
     <Version>0.1.0.0</Version>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)'=='Release.Signed'">
-    <OutputPath>bin\Release.Signed\</OutputPath>
-    <Optimize>true</Optimize>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>ClosedXML.Report.snk</AssemblyOriginatorKeyFile>
-    <DefineConstants>$(DefineConstants);RELEASE;STRONGNAME</DefineConstants>
+    <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <Compile Remove="FiledBuilderTests.cs" />
   </ItemGroup>
@@ -31,7 +26,7 @@
   <ItemGroup>
     <PackageReference Include="Bogus" Version="34.0.2" />
     <PackageReference Include="ClosedXML" Version="0.96.0" />
-    <PackageReference Include="DocumentFormat.OpenXml" Version="2.18.0" />
+    <PackageReference Include="DocumentFormat.OpenXml" Version="2.16.0" />
     <PackageReference Include="FluentAssertions" Version="6.7.0" />
     <PackageReference Include="linq2db" Version="4.3.0" />
     <PackageReference Include="linq2db.SQLite" Version="4.3.0" />

--- a/tests/ClosedXML.Report.Tests/ClosedXML.Report.Tests.csproj
+++ b/tests/ClosedXML.Report.Tests/ClosedXML.Report.Tests.csproj
@@ -30,21 +30,22 @@
 
   <ItemGroup>
     <PackageReference Include="Bogus" Version="34.0.2" />
-    <PackageReference Include="DocumentFormat.OpenXml" Version="2.16.0" />
+    <PackageReference Include="ClosedXML" Version="0.96.0" />
+    <PackageReference Include="DocumentFormat.OpenXml" Version="2.18.0" />
     <PackageReference Include="FluentAssertions" Version="6.7.0" />
-    <PackageReference Include="linq2db" Version="3.7.0" />
-    <PackageReference Include="linq2db.SQLite" Version="3.7.0" />
-    <PackageReference Include="linq2db.t4models" Version="3.7.0" />
+    <PackageReference Include="linq2db" Version="4.3.0" />
+    <PackageReference Include="linq2db.SQLite" Version="4.3.0" />
+    <PackageReference Include="linq2db.t4models" Version="4.3.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-    <PackageReference Include="NSubstitute" Version="4.3.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
-    <PackageReference Include="System.Linq.Dynamic.Core" Version="1.2.18" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="NSubstitute" Version="4.4.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.1" />
+    <PackageReference Include="System.Linq.Dynamic.Core" Version="1.2.20" />
     <PackageReference Include="System.Resources.Extensions" Version="6.0.0" />
-    <PackageReference Include="System.ServiceModel.Primitives" Version="4.9.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.assert" Version="2.4.1" />
-    <PackageReference Include="xunit.extensibility.execution" Version="2.4.1" />
+    <PackageReference Include="System.ServiceModel.Primitives" Version="4.10.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.assert" Version="2.4.2" />
+    <PackageReference Include="xunit.extensibility.execution" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/ClosedXML.Report.Tests/XlsxTemplateTestsBase.cs
+++ b/tests/ClosedXML.Report.Tests/XlsxTemplateTestsBase.cs
@@ -136,28 +136,28 @@ namespace ClosedXML.Report.Tests
                 }
 
                 if (expectedCell.HasComment != actualCell.HasComment
-                    || (expectedCell.HasComment && !Equals(expectedCell.Comment, actualCell.Comment)))
+                    || (expectedCell.HasComment && !Equals(expectedCell.GetComment(), actualCell.GetComment())))
                 {
                     messages.Add($"Cell comments are not equal starting from {address}");
                     cellsAreEqual = false;
                 }
 
                 if (expectedCell.HasHyperlink != actualCell.HasHyperlink
-                    || (expectedCell.HasHyperlink && !Equals(expectedCell.Hyperlink, actualCell.Hyperlink)))
+                    || (expectedCell.HasHyperlink && !Equals(expectedCell.GetHyperlink(), actualCell.GetHyperlink())))
                 {
                     messages.Add($"Cell Hyperlink are not equal starting from {address}");
                     cellsAreEqual = false;
                 }
 
                 if (expectedCell.HasRichText != actualCell.HasRichText
-                    || (expectedCell.HasRichText && !expectedCell.RichText.Equals(actualCell.RichText)))
+                    || (expectedCell.HasRichText && !expectedCell.GetRichText().Equals(actualCell.GetRichText())))
                 {
                     messages.Add($"Cell RichText are not equal starting from {address}");
                     cellsAreEqual = false;
                 }
 
                 if (expectedCell.HasDataValidation != actualCell.HasDataValidation
-                    || (expectedCell.HasDataValidation && !Equals(expectedCell.DataValidation, actualCell.DataValidation)))
+                    || (expectedCell.HasDataValidation && !Equals(expectedCell.GetDataValidation(), actualCell.GetDataValidation())))
                 {
                     messages.Add($"Cell DataValidation are not equal starting from {address}");
                     cellsAreEqual = false;


### PR DESCRIPTION
Updated and tested

1. ClosedXML updated to version 0.96
2. ClosedXML.Report now became signed; ClosedXML.Report.Signed has been dropped (see https://github.com/ClosedXML/ClosedXML/pull/1552 and https://github.com/ClosedXML/ClosedXML/issues/1547 for wider context)
3. OpenXML version unified in tests.
4. Version bumbed to 0.2.5.

Closes #194 