### PR TITLE
Forcibly remove a range representing a table if its data source is empty (#251)

### DIFF
--- a/ClosedXML.Report/RangeInterpreter.cs
+++ b/ClosedXML.Report/RangeInterpreter.cs
@@ -177,6 +177,20 @@ namespace ClosedXML.Report
                 {
                     var growedRange = rng.GrowToMergedRanges();
                     var items = nr.RangeData as object[] ?? nr.RangeData.Cast<object>().ToArray();
+                    if (!items.Any())
+                    {
+                        if (growedRange.IsOptionsRowEmpty())
+                        {
+                            growedRange.Delete(XLShiftDeletedCells.ShiftCellsUp);
+                        }
+                        else
+                        {
+                            var rangeWithoutOptionsRow = growedRange.Worksheet
+                                .Range(growedRange.FirstCell(), growedRange.LastCell().CellAbove());
+                            rangeWithoutOptionsRow.Delete(XLShiftDeletedCells.ShiftCellsUp);
+                        }
+                        continue;
+                    }
                     var tplt = RangeTemplate.Parse(nr.NamedRange.Name, growedRange, _errors, _variables);
                     using (var buff = tplt.Generate(items))
                     {

--- a/tests/ClosedXML.Report.Tests/RangeInterpreterTests.cs
+++ b/tests/ClosedXML.Report.Tests/RangeInterpreterTests.cs
@@ -104,6 +104,37 @@ namespace ClosedXML.Report.Tests
             ws.Cell("B4").GetString().Should().Be("Material 1");
         }
 
+        [Fact]
+        public void ShouldDestroyEmptyTable()
+        {
+            //See #251
+            var template = CreateOrderTemplate();
+            var ws = template.Workbook.Worksheets.First();
+
+            ws.Cell("B4").SetValue("This list is empty");
+            ws.Cell("B5").SetValue("{{item.Name}}");
+            ws.Range("A5:B6").AddToNamed("Empty");
+
+            ws.Cell("B7").SetValue("This list is populated");
+            ws.Cell("B8").SetValue("{{item.Name}}");
+            ws.Range("A8:B9").AddToNamed("Populated");
+
+            var model = new
+            {
+                Empty = new List<Item>(),
+                Populated = new[]
+                {
+                    new Item("It works", null)
+                }
+            };
+            template.AddVariable(model);
+            template.Generate();
+
+            ws.Cell("B4").GetString().Should().Be("This list is empty");
+            ws.Cell("B5").GetString().Should().Be("This list is populated");
+            ws.Cell("B6").GetString().Should().Be("It works");
+        }
+
         private XLTemplate CreateOrderTemplate()
         {
             var wbTemplate = new XLWorkbook();

--- a/tests/ClosedXML.Report.Tests/TempSheetBufferTests.cs
+++ b/tests/ClosedXML.Report.Tests/TempSheetBufferTests.cs
@@ -41,8 +41,8 @@ namespace ClosedXML.Report.Tests
                 template.AddVariable("List", new List<string>());
                 template.Generate();
 
-                ws.Cell("B3").GetString().Should().Be("Cell below");
-                ws.Cell("B4").GetString().Should().Be("");
+                ws.Cell("B2").GetString().Should().Be("Cell below");
+                ws.Cell("B3").GetString().Should().Be("");
             }
         }
 


### PR DESCRIPTION
Closes #251

For rendering tables, ClosedXML.Report uses a temporary worksheet where it creates a whole table which then is copied to the original worksheet. But when the datasource for the table is empty, no data gets rendered on the temp worksheet and this caused incorrect buffer copying that corrupted ranges below.

With this fix, we prevent empty tables from rendering and remove the template rows (preserving an options row, if necessary).