### PR TITLE
when the data source includes an underscore (_)

### DIFF
--- a/ClosedXML.Report/RangeInterpreter.cs
+++ b/ClosedXML.Report/RangeInterpreter.cs
@@ -8,6 +8,7 @@ using ClosedXML.Report.Excel;
 using ClosedXML.Report.Options;
 using ClosedXML.Report.Utils;
 using System.Linq.Dynamic.Core.Exceptions;
+using System.Text.RegularExpressions;
 
 
 namespace ClosedXML.Report
@@ -248,7 +249,36 @@ namespace ClosedXML.Report
                 variableValue is IEnumerable data1)
                 return new BoundRange(namedRange, data1);
 
-            var expression = "{{" + namedRange.Name.Replace("_", ".") +"}}";
+            // Get the name of the named range
+            var input = namedRange.Name;
+
+            // Define a regular expression pattern to match parts of the string that are enclosed in backslashes
+            string pattern = @"\\(.*?)\\";
+
+            // Use the regular expression to find all matches in the input string
+            var matches = Regex.Matches(input, pattern);
+
+            // Iterate over each match found
+            foreach (Match match in matches)
+            {
+                // Replace underscores in the matched string with caret symbols
+                string replacement = match.Value.Replace("_", "^");
+
+                // Replace the matched part in the input string with the modified string
+                input = input.Replace(match.Value, replacement);
+            }
+
+            // Remove all backslashes from the input string
+            input = input.Replace("\\", "");
+
+            // Replace all remaining underscores in the input string with dots
+            input = input.Replace("_", ".");
+
+            // Replace all caret symbols in the input string back to underscores
+            input = input.Replace("^", "_");
+
+            // Create an expression by enclosing the modified input string in double curly braces
+            var expression = "{{" + input +"}}";
 
             if (_evaluator.TryEvaluate(expression, out var res) &&
                 res is IEnumerable data2)

--- a/ClosedXML.Report/RangeTemplate.cs
+++ b/ClosedXML.Report/RangeTemplate.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Dynamic.Core.Exceptions;
 using System.Reflection;
-
+using System.Text.RegularExpressions;
 using ClosedXML.Excel;
 using ClosedXML.Report.Excel;
 using ClosedXML.Report.Options;
@@ -368,7 +368,27 @@ namespace ClosedXML.Report
         {
             var start = _buff.NextAddress;
             // the child template to which the cell belongs
-            var formula = ownRng.Source.ReplaceLast("_", ".");
+            // Define a regular expression pattern to match parts of the string that are enclosed in backslashes
+            string pattern = @"\\(.*?)\\";
+            var formula = ownRng.Source;
+            var matches = Regex.Matches(formula, pattern);
+            // Iterate over each match found
+            foreach (Match match in matches)
+            {
+                // Replace underscores in the matched string with caret symbols
+                string replacement = match.Value.Replace("_", "^");
+
+                // Replace the matched part in the input string with the modified string
+                formula = formula.Replace(match.Value, replacement);
+            }
+
+            // Remove all backslashes from the input string
+            formula = formula.Replace("\\", "");
+
+            formula = formula.ReplaceLast("_", ".");
+            formula = formula.Replace("^", "_");
+
+            //var formula = ownRng.Source.ReplaceLast("_", ".");
 
             if (evaluator.Evaluate(formula, new Parameter(Name, item)) is IEnumerable value)
             {


### PR DESCRIPTION

When the variables in the range name contain underscores, they can be enclosed using backslashes, for example: 
```c
Customers[].Orders[].BS_Items[], 
```
```c
Customers_Orders_\BS_Items\
```

closed #336 