### PR TITLE
Add Height and HeightRange option. #360

### DIFF
--- a/ClosedXML.Report/Options/HeightRangeTag.cs
+++ b/ClosedXML.Report/Options/HeightRangeTag.cs
@@ -1,0 +1,18 @@
+﻿using System.Linq;
+using ClosedXML.Report.Utils;
+
+namespace ClosedXML.Report.Options
+{
+    public class HeightRangeTag : RangeOptionTag
+    {
+        public int Height => Parameters.Any() ? Parameters.First().Key.AsInt() : 0;
+
+        public override void Execute(ProcessingContext context)
+        {
+            var firstRow = context.Range.FirstRowUsed();
+            var lastRow = context.Range.LastRowUsed();
+
+            Range.Worksheet.Rows(firstRow.WorksheetRow().RowNumber(), lastRow.WorksheetRow().RowNumber()).Height = Height;
+        }
+    }
+}

--- a/ClosedXML.Report/Options/HeightTag.cs
+++ b/ClosedXML.Report/Options/HeightTag.cs
@@ -1,0 +1,17 @@
+﻿using System.Linq;
+using ClosedXML.Report.Utils;
+
+namespace ClosedXML.Report.Options;
+
+public class HeightTag : OptionTag
+{
+    public int Height => Parameters.Any() ? Parameters.First().Key.AsInt() : 0;
+
+    public override void Execute(ProcessingContext context)
+    {
+        var xlCell = Cell.GetXlCell(context.Range);
+        var cellRow = xlCell.WorksheetRow().RowNumber();
+
+        Range.Worksheet.Rows(cellRow, cellRow).Height = Height;
+    }
+}

--- a/ClosedXML.Report/RangeTemplate.cs
+++ b/ClosedXML.Report/RangeTemplate.cs
@@ -146,11 +146,11 @@ namespace ClosedXML.Report
         public IReportBuffer Generate(object[] items)
         {
             _evaluator.AddVariable("items", items);
+
             foreach (var v in _globalVariables)
             {
                 _evaluator.AddVariable("@" + v.Key, v.Value);
             }
-            _rangeTags.Reset();
 
             if (IsHorizontal)
             {
@@ -160,6 +160,7 @@ namespace ClosedXML.Report
             {
                 VerticalTable(items, _evaluator);
             }
+
             return _buff;
         }
 
@@ -482,10 +483,16 @@ namespace ClosedXML.Report
                     tags = _tagsEvaluator.Parse(cell.GetString(), range, cell, out newValue);
                     cell.Value = newValue;
                 }
-                if (cell.Row > 1 && cell.Row == _rowCnt)
-                    _rangeTags.AddRange(tags);
-                else
-                    _tags.AddRange(tags);
+
+                foreach (var optionTag in tags)
+                {
+                    if (cell.Row > 1 && cell.Row == _rowCnt)
+                        _rangeTags.Add(optionTag);
+                    else if (optionTag is RangeOptionTag)
+                        _rangeTags.Add(optionTag);
+                    else
+                        _tags.Add(optionTag);
+                }
             }
 
             _rangeOption = _rangeTags.GetAll<RangeOptionTag>().Union(_tags.GetAll<RangeOptionTag>()).FirstOrDefault();

--- a/ClosedXML.Report/XLTemplate.cs
+++ b/ClosedXML.Report/XLTemplate.cs
@@ -58,6 +58,8 @@ namespace ClosedXML.Report
             TagsRegister.Add<HiddenTag>("Hide", 0);
             TagsRegister.Add<PageOptionsTag>("PageOptions", 0);
             TagsRegister.Add<ProtectedTag>("Protected", 0);
+            TagsRegister.Add<HeightTag>("Height", 0);
+            TagsRegister.Add<HeightRangeTag>("HeightRange", 0);
         }
 
         public XLTemplate(string fileName) : this(new XLWorkbook(fileName))


### PR DESCRIPTION
**Pull Request Description**

### Summary
I have added two new tags to the library, `<<Height number>>` and `<<HeightRange number>>`, which allow users to set the height for individual rows and a range of rows respectively.

### Changes Made
1. **`<<Height number>>` Tag**: This tag sets the height for a specific row. When this tag is processed, the row height is adjusted according to the specified number.
   
   **Example Usage**:
   ```
   <<Height 20>>
   ```
   After processing, the row containing this tag will have a height of 20 units.

2. **`<<HeightRange number>>` Tag**: This tag sets the height for a range of rows. When this tag is processed, the specified range of rows will have their heights set to the given number.
   
   **Example Usage**:
   ```
   <<HeightRange 30>>
   ```
   After processing, the rows in the specified range will each have a height of 30 units.

### Detailed Implementation
- The `<<Height number>>` tag parses the number and applies it to the height property of the targeted row.
- The `<<HeightRange number>>` tag parses the number and applies it to the height property of the rows within the specified range.

These enhancements aim to provide more flexibility and control over row formatting in the library.

Thank you for considering this pull request. I believe these additions will greatly benefit users by providing more precise control over row heights.
