### PR TITLE
tidy: Remove outdated #ifdef logic, remove unused utility code.

### DIFF
--- a/ClosedXML.Report/Utils/EnumExtensions.cs
+++ b/ClosedXML.Report/Utils/EnumExtensions.cs
@@ -1,177 +1,38 @@
 ﻿using System;
 using System.ComponentModel;
-using System.Globalization;
 using System.Linq;
 using System.Reflection;
 
 namespace ClosedXML.Report.Utils
 {
     /// <summary>
-    /// uses extension methods to convert enums with hypens in their names to underscore and other variants
+    /// uses extension methods to convert enums with hyphens in their names to underscore and other variants
     /// </summary>
     public static class EnumExtensions
     {
-        /// <summary>
-        /// Gets the description string, if available. Otherwise returns the name of the enum field
-        /// LthWrapper.POS.Dollar.GetString() yields "$", an impossible control character for enums
-        /// </summary>
-        /// <param name="value"></param>
-        /// <returns></returns>
-        public static string GetString(this Enum value)
-        {
-            Type type = value.GetType();
-            string name = GetName(type, value);
-            FieldInfo field = type.GetField(name);
-
-            if (field != null &&
-                Attribute.GetCustomAttribute(field, typeof(DescriptionAttribute)) is DescriptionAttribute attr)
-            {
-                //return the description if we have it
-                name = attr.Description;
-            }
-
-            return name;
-        }
-
-
-        public static string[] GetStrings(Type enumType)
-        {
-            if (enumType == null)
-                throw new ArgumentNullException("enumType");
-            if (!enumType.IsEnum)
-                throw new ArgumentException("Argument 'enumType' must be enum");
-
-            FieldInfo[] fieldInfo = enumType.GetFields(BindingFlags.Static | BindingFlags.Public);
-            return (from field in fieldInfo
-                    let attr = (DescriptionAttribute)Attribute.GetCustomAttribute(field, typeof(DescriptionAttribute))
-                    select attr != null ? attr.Description : field.Name)
-                .ToArray();
-        }
-
-        public static Array GetValues(Type enumType)
-        {
-#if !WindowsCE
-            return Enum.GetValues(enumType);
-#else
-            if (enumType == null)
-                throw new ArgumentNullException("enumType");
-            if (!enumType.IsEnum)
-                throw new ArgumentException("Argument 'enumType' must be enum");
-
-            object valAux = Activator.CreateInstance(enumType);
-            FieldInfo[] fieldInfoArray = enumType.GetFields(BindingFlags.Static | BindingFlags.Public);
-
-            Array res = Array.CreateInstance(enumType, fieldInfoArray.Length);
-            for (int i = 0; i < res.Length; i++)
-                res.SetValue(fieldInfoArray[i].GetValue(valAux), i);
-            return res;
-#endif
-        }
-
-        /// <summary>
-        /// Converts a string to an enum field using the string first; if that fails, tries to find a description
-        /// attribute that matches. 
-        /// "$".ToEnum&lt;LthWrapper.POS>() yields POS.Dollar
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="value"></param>
-        /// <returns></returns>
-        public static T ToEnum<T>(this string value) //, T defaultValue)
-        {
-            return (T)Parse(typeof(T), value, true);
-        }
-        private static ulong ToUInt64(object value)
-        {
-            switch (Convert.GetTypeCode(value))
-            {
-                case TypeCode.SByte:
-                case TypeCode.Int16:
-                case TypeCode.Int32:
-                case TypeCode.Int64:
-                    return (ulong)Convert.ToInt64(value, (IFormatProvider)CultureInfo.InvariantCulture);
-                case TypeCode.Byte:
-                case TypeCode.UInt16:
-                case TypeCode.UInt32:
-                case TypeCode.UInt64:
-                    return Convert.ToUInt64(value, (IFormatProvider)CultureInfo.InvariantCulture);
-                default:
-                    throw new InvalidOperationException("Invalid operation: Unknown enum type");
-            }
-        }
-
-        public static string GetName(Type enumType, object value)
-        {
-#if WindowsCE
-            if (enumType == null)
-                throw new ArgumentNullException("enumType");
-            if (!enumType.IsEnum)
-                throw new ArgumentException("Argument 'enumType' must be enum");
-            if (value == null)
-                throw new ArgumentNullException("value");
-
-            Type type = value.GetType();
-            if (type.IsEnum || type == typeof(int) || (type == typeof(short) || type == typeof(ushort)) || (type == typeof(byte) || type == typeof(sbyte) || (type == typeof(uint) || type == typeof(long))) || type == typeof(ulong))
-            {
-                ulong num = ToUInt64(value);
-                FieldInfo[] fieldInfo = enumType.GetFields(BindingFlags.Static | BindingFlags.Public);
-
-                for (int i = 0; i < fieldInfo.Length; i++)
-                    if (ToUInt64(fieldInfo[i].GetValue(value)) == num)
-                        return fieldInfo[i].Name;
-
-                throw new ArgumentOutOfRangeException("value");
-            }
-            else
-                throw new ArgumentException("Argument 'value' must be enum base type or enum");
-#else
-            return Enum.GetName(enumType, value);
-#endif
-        }
-
-        public static string[] GetNames(Type enumType)
-        {
-            if (enumType == null)
-                throw new ArgumentNullException("enumType");
-            if (!enumType.IsEnum)
-                throw new ArgumentException("Argument 'enumType' must be enum");
-
-            FieldInfo[] fieldInfo = enumType.GetFields(BindingFlags.Static | BindingFlags.Public);
-            return fieldInfo.Select(f => f.Name).ToArray();
-        }
-
         public static object Parse(Type enumType, string value, bool ignoreCase)
         {
-            if (value == null) throw new ArgumentNullException("value");
+            if (value == null) throw new ArgumentNullException(nameof(value));
             value = value.Trim();
-            /*if (enumType == null) throw new ArgumentNullException("enumType");
-            if (!enumType.IsEnum)
-                throw new ArgumentException("enumType is not an Enum.");
-            
-            FieldInfo[] fieldInfo = enumType.GetFields(BindingFlags.Static | BindingFlags.Public);
-            foreach (FieldInfo field in fieldInfo)
-            {
-                DescriptionAttribute attr = (DescriptionAttribute) Attribute.GetCustomAttribute(field, typeof (DescriptionAttribute));
-                if (string.Compare(value, attr.Description, ignoreCase) == 0 || string.Compare(value, field.Name, ignoreCase) == 0)
-                    return field.GetValue(null);
-            }*/
             var results = GetEnumValues(enumType, i => string.Compare(value, i, ignoreCase) == 0);
             if (results.Length != 1)
-                throw new ArgumentException("value is a name, but not one of the named constants defined for the enumeration.");
+                throw new ArgumentException(
+                    "value is a name, but not one of the named constants defined for the enumeration.");
             return results[0];
         }
 
-        public static object[] GetEnumValues(Type enumType, Predicate<string> checkPredicate)
+        private static object[] GetEnumValues(Type enumType, Predicate<string> checkPredicate)
         {
-            if (enumType == null) throw new ArgumentNullException("enumType");
-            if (checkPredicate == null) throw new ArgumentNullException("checkPredicate");
+            if (enumType == null) throw new ArgumentNullException(nameof(enumType));
+            if (checkPredicate == null) throw new ArgumentNullException(nameof(checkPredicate));
             if (!enumType.IsEnum)
                 throw new ArgumentException("enumType is not an Enum.");
 
-            FieldInfo[] fieldInfo = enumType.GetFields(BindingFlags.Static | BindingFlags.Public);
+            var fieldInfo = enumType.GetFields(BindingFlags.Static | BindingFlags.Public);
             return (from field in fieldInfo
-                    let attr = (DescriptionAttribute)Attribute.GetCustomAttribute(field, typeof(DescriptionAttribute))
-                    where (attr != null && checkPredicate(attr.Description)) || checkPredicate(field.Name)
-                    select field.GetValue(null)).ToArray();
+                let attr = (DescriptionAttribute)Attribute.GetCustomAttribute(field, typeof(DescriptionAttribute))
+                where (attr != null && checkPredicate(attr.Description)) || checkPredicate(field.Name)
+                select field.GetValue(null)).ToArray();
         }
     }
 }

--- a/ClosedXML.Report/Utils/TypeExtensions.cs
+++ b/ClosedXML.Report/Utils/TypeExtensions.cs
@@ -2,14 +2,12 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Linq.Expressions;
-using System.Reflection;
 
 namespace ClosedXML.Report.Utils
 {
     public static class TypeExtensions
     {
-        private static readonly HashSet<Type> NumericTypes = new HashSet<Type>
+        private static readonly HashSet<Type> NumericTypes = new()
         {
             typeof(byte), typeof(sbyte), typeof(short), typeof(ushort), typeof(int),
             typeof(uint), typeof(long), typeof(ulong), typeof(double), typeof(decimal), typeof(float)
@@ -17,7 +15,7 @@ namespace ClosedXML.Report.Utils
 
         public static bool IsPrimitive(this Type type)
         {
-            if (type == typeof(string) || type.IsEnum || type == typeof(DateTime) 
+            if (type == typeof(string) || type.IsEnum || type == typeof(DateTime)
                 || type == typeof(Guid) || type == typeof(decimal) || type.IsNullable()) return true;
             return (type.IsValueType & type.IsPrimitive);
         }
@@ -32,8 +30,8 @@ namespace ClosedXML.Report.Utils
             else
             {
                 var genericType = (from intType in type.GetInterfaces()
-                                   where intType.IsGenericType && intType.GetGenericTypeDefinition() == typeof(IEnumerable<>)
-                                   select intType.GetGenericArguments()[0]).FirstOrDefault();
+                    where intType.IsGenericType && intType.GetGenericTypeDefinition() == typeof(IEnumerable<>)
+                    select intType.GetGenericArguments()[0]).FirstOrDefault();
 
                 if (genericType != null)
                     return genericType;
@@ -73,68 +71,6 @@ namespace ClosedXML.Report.Utils
                    NumericTypes.Contains(Nullable.GetUnderlyingType(type));
         }
 
-        public static Type ToType(this TypeCode code)
-        {
-            switch (code)
-            {
-                case TypeCode.Boolean:
-                    return typeof(bool);
-
-                case TypeCode.Byte:
-                    return typeof(byte);
-
-                case TypeCode.Char:
-                    return typeof(char);
-
-                case TypeCode.DateTime:
-                    return typeof(DateTime);
-
-                case TypeCode.DBNull:
-                    return typeof(DBNull);
-
-                case TypeCode.Decimal:
-                    return typeof(decimal);
-
-                case TypeCode.Double:
-                    return typeof(double);
-
-                case TypeCode.Empty:
-                    return null;
-
-                case TypeCode.Int16:
-                    return typeof(short);
-
-                case TypeCode.Int32:
-                    return typeof(int);
-
-                case TypeCode.Int64:
-                    return typeof(long);
-
-                case TypeCode.Object:
-                    return typeof(object);
-
-                case TypeCode.SByte:
-                    return typeof(sbyte);
-
-                case TypeCode.Single:
-                    return typeof(Single);
-
-                case TypeCode.String:
-                    return typeof(string);
-
-                case TypeCode.UInt16:
-                    return typeof(UInt16);
-
-                case TypeCode.UInt32:
-                    return typeof(UInt32);
-
-                case TypeCode.UInt64:
-                    return typeof(UInt64);
-            }
-
-            return null;
-        }
-
         public static bool IsNullable(this Type type)
         {
             return type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>);
@@ -146,87 +82,8 @@ namespace ClosedXML.Report.Utils
             {
                 return Activator.CreateInstance(type);
             }
+
             return null;
         }
-
-        public static PropertyInfo GetPropertyInfo(this Type type, string fieldName, BindingFlags flags = BindingFlags.Instance | BindingFlags.Public)
-        {
-            var property = type.GetProperty(fieldName, flags);
-#if NET35
-            if (property == null) throw new MissingMemberException(string.Format("Invalid property {0}.{1}", type.Name, fieldName));
-#else
-            if (property == null) throw new MissingMemberException(type.Name, fieldName);
-#endif
-            return property;
-        }
-
-        public static bool IsAssignableToGenericType(this Type givenType, Type genericType)
-        {
-            var interfaceTypes = givenType.GetInterfaces();
-
-            if (interfaceTypes.Any(it => it.IsGenericType && it.GetGenericTypeDefinition() == genericType))
-                return true;
-
-            if (givenType.IsGenericType && givenType.GetGenericTypeDefinition() == genericType)
-                return true;
-
-            Type baseType = givenType.BaseType;
-            return baseType != null && IsAssignableToGenericType(baseType, genericType);
-        }
-
-#if !WindowsCE
-        public static PropertyInfo GetPropertyInfo<TSource, TProperty>(
-            this Type type,
-            Expression<Func<TSource, TProperty>> propertyLambda)
-        {
-            if (!(propertyLambda.Body is MemberExpression member))
-                throw new ArgumentException(string.Format(
-                    "Expression '{0}' refers to a method, not a property.",
-                    propertyLambda.ToString()));
-
-            PropertyInfo propInfo = member.Member as PropertyInfo;
-            if (propInfo == null)
-                throw new ArgumentException(string.Format(
-                    "Expression '{0}' refers to a field, not a property.",
-                    propertyLambda.ToString()));
-
-            if (type != propInfo.ReflectedType &&
-                !type.IsSubclassOf(propInfo.ReflectedType))
-                throw new ArgumentException(string.Format(
-                    "Expresion '{0}' refers to a property that is not from type {1}.",
-                    propertyLambda.ToString(),
-                    type));
-
-            return propInfo;
-        }
-#endif
-
-        public static object GetInstanceField(this Type type, object instance, string fieldName)
-        {
-            BindingFlags bindFlags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic
-                | BindingFlags.Static;
-            FieldInfo field = type.GetField(fieldName, bindFlags);
-            return field.GetValue(instance);
-        }
-
-        public static object Invoke(this Type type, object instance, string methodName, params object[] methodParams)
-        {
-            MethodInfo dynMethod = type.GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Instance);
-            return dynMethod.Invoke(instance, methodParams);
-        }
-
-#if NET20 || NET35 || WindowsCE 
-        public static T GetCustomAttribute<T>(this MemberInfo member, bool inherit)
-            where T : Attribute
-        {
-            return (T)Attribute.GetCustomAttribute(member, typeof (T), inherit);
-        }
-
-        public static T GetCustomAttribute<T>(this ParameterInfo member, bool inherit)
-            where T : Attribute
-        {
-            return (T)Attribute.GetCustomAttribute(member, typeof (T), inherit);
-        }
-#endif
     }
 }

--- a/ClosedXML.Report/Utils/VernoStringReader.cs
+++ b/ClosedXML.Report/Utils/VernoStringReader.cs
@@ -353,7 +353,6 @@ namespace ClosedXML.Report.Utils
                 return failure != null ? failure(str) : DateTime.MinValue;
         }
 
-#if !NET40
         /// <summary>Асинхронно выполняет чтение строки символов из текущей строки и возвращает данные в виде строки.</summary>
         /// <returns>Задача, представляющая асинхронную операцию чтения.Значение параметра <paramref name="TResult" /> содержит следующую строку из средства чтения строк или значение null, если все знаки считаны.</returns>
         /// <exception cref="T:System.ArgumentOutOfRangeException">Количество символов в следующей строке больше <see cref="F:System.Int32.MaxValue" />.</exception>
@@ -419,7 +418,6 @@ namespace ClosedXML.Report.Utils
                 throw new ArgumentException("Argument invalid off len");
             return Task.FromResult(Read(buffer, index, count));
         }
-#endif
 
         internal static void ReaderClosed()
         {

--- a/ClosedXML.Report/Utils/VernoStringReader.cs
+++ b/ClosedXML.Report/Utils/VernoStringReader.cs
@@ -96,11 +96,11 @@ namespace ClosedXML.Report.Utils
         public override int Read([In, Out] char[] buffer, int index, int count)
         {
             if (buffer == null)
-                throw new ArgumentNullException("buffer");
+                throw new ArgumentNullException(nameof(buffer));
             if (index < 0)
-                throw new ArgumentOutOfRangeException("index");
+                throw new ArgumentOutOfRangeException(nameof(index));
             if (count < 0)
-                throw new ArgumentOutOfRangeException("count");
+                throw new ArgumentOutOfRangeException(nameof(count));
             if (buffer.Length - index < count)
                 throw new ArgumentException("Argument invalid off len");
             if (_s == null)


### PR DESCRIPTION
This pull request removes unused or outdated code and improves code quality in the `ClosedXML.Report.Utils` namespace. The changes primarily focus on cleaning up redundant methods, modernizing syntax, and improving parameter validation.

### Code cleanup and removal of unused methods:
* Removed numerous unused extension methods from `EnumExtensions`, including `GetString`, `GetStrings`, `ToEnum`, and others. These methods were either redundant or not used in the current codebase.
* Removed unused methods such as `ToType`, `GetPropertyInfo`, `IsAssignableToGenericType`, and others from `TypeExtensions`. These methods were no longer relevant or needed. [[1]](diffhunk://#diff-29ec4622d9e7e8c64b89a80d5bb87f91d785bb030b730646d63c43933b5b2ed2L149-L230) [[2]](diffhunk://#diff-29ec4622d9e7e8c64b89a80d5bb87f91d785bb030b730646d63c43933b5b2ed2L76-L137)

### Syntax improvements:
* Simplified the initialization of the `NumericTypes` `HashSet` in `TypeExtensions` using modern C# syntax.
* Replaced string literals with `nameof` for argument validation in `EnumExtensions` to improve maintainability and reduce potential errors.

### Platform-specific code removal:
* Removed conditional compilation directives (`#if !WindowsCE` and `#if !NET40`) from `EnumExtensions` and `VernoStringReader` as they are no longer relevant. [[1]](diffhunk://#diff-5c714b57e02a28d6cb9418e11a5da9925a28a58ca47b32989d443231bd63d9c5L3-R31) [[2]](diffhunk://#diff-93b5ca02b8bf2c7f56adf88a271ad27a38f75bb07b4e1e43f87b3cfeffbf4bf8L356) [[3]](diffhunk://#diff-93b5ca02b8bf2c7f56adf88a271ad27a38f75bb07b4e1e43f87b3cfeffbf4bf8L422)